### PR TITLE
support deploying to gh-pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Support
+- redirect index route to simple example
+- prevent HTTP (only) requests caused by `detect: true`
+- added script to deploy to gh-pages
+
 ## 0.3.0
 ### Added
 - listen for changes to lat/lng and update viewer location

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "build": "ember build",
     "start": "ember server",
-    "test": "ember try:testall"
+    "test": "ember try:testall",
+    "deploy": "./scripts/deploy-gh.sh"
   },
   "repository": {
     "type": "git",

--- a/scripts/deploy-gh.sh
+++ b/scripts/deploy-gh.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+git checkout gh-pages
+git merge master -m "merge master and prepare to deploy"
+ember build --environment gh-pages
+git add dist --force
+git commit -m "deploy to gh-pages"
+git subtree push --prefix dist upstream gh-pages
+git checkout master

--- a/tests/dummy/app/controllers/map-two-way.js
+++ b/tests/dummy/app/controllers/map-two-way.js
@@ -10,8 +10,7 @@ export default Ember.Controller.extend({
 
   // mapillary viewer configuration
   mapillaryOptions: {
-    cover: false,
-    detection: true
+    cover: false
   },
 
   // map center and zoom

--- a/tests/dummy/app/routes/index.js
+++ b/tests/dummy/app/routes/index.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  beforeModel() {
+    this.transitionTo('simple');
+  }
+});

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -17,17 +17,6 @@ module.exports = function(environment) {
       // Here you can pass flags/options to your application instance
       // when it is created
       mapillaryClientId: 'cjJ1SUtVOEMtdy11b21JM0tyYTZIQTo2ZmVjNTQ3YWQ0OWI2Yjgx',
-      mapillaryVectorLayerConfig: {
-        url: 'https://d2munx5tg0hw47.cloudfront.net/tiles/{z}/{x}/{y}.mapbox',
-        maxZoom: 18,
-        style: function (/*feature*/) {
-          var style = {};
-          style.color = 'rgba(0, 255, 0, 0.7)';
-          style.size = 3;
-
-          return style;
-        }
-      }
     }
   };
 
@@ -53,6 +42,12 @@ module.exports = function(environment) {
 
   if (environment === 'production') {
 
+  }
+
+  // for gh-pages deploy
+  if (environment === 'gh-pages') {
+    ENV.baseURL = '/ember-cli-mapillary/';
+    ENV.locationType = 'hash';
   }
 
   return ENV;


### PR DESCRIPTION
- redirect index route to simple example
- prevent HTTP (only) requests caused by `detect: true`
- added script to deploy to gh-pages

resolves #3 
