### PR TITLE
fix move to key bug and add example to dummy app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## 0.5.1
 ### Changed
 - use correct Mapillary API method move to key (moveToKey, not moveCloseKey)
+- update to MapillaryJS v1.4.2
 ### Support
 - add GitHub and MapillaryJS links to dummy app
 - add example of how to use move to key in dummy app

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.5.1
+### Changed
+- use correct Mapillary API method move to key (moveToKey, not moveCloseKey)
+### Support
+- add GitHub and MapillaryJS links to dummy app
+- add example of how to use move to key in dummy app
+
 ## 0.5.0
 ### Added
 - raise an action (onLoadingChanged) whenever the loading state changes

--- a/addon/components/mapillary-viewer/component.js
+++ b/addon/components/mapillary-viewer/component.js
@@ -59,7 +59,7 @@ export default Ember.Component.extend({
       return this.viewer.moveCloseTo(val[0], val[1]);
     } else {
       // move to key
-      return this.viewer.moveCloseKey(val);
+      return this.viewer.moveToKey(val);
     }
   },
 

--- a/index.js
+++ b/index.js
@@ -54,10 +54,10 @@ module.exports = {
   // TODO: once resolved, remove the following code
   contentFor: function(type/*, config*/) {
     if (type === 'head') {
-      return '<link rel="stylesheet" href="//npmcdn.com/mapillary-js@1.4.1/dist/mapillary-js.min.css">';
+      return '<link rel="stylesheet" href="//npmcdn.com/mapillary-js@1.4.2/dist/mapillary-js.min.css">';
     }
     if (type === 'body') {
-      return '<script src="//npmcdn.com/mapillary-js@1.4.1/dist/mapillary-js.min.js"></script>';
+      return '<script src="//npmcdn.com/mapillary-js@1.4.2/dist/mapillary-js.min.js"></script>';
     }
   }
 };

--- a/tests/dummy/app/controllers/move-to-key.js
+++ b/tests/dummy/app/controllers/move-to-key.js
@@ -1,0 +1,22 @@
+import Ember from 'ember';
+import config from '../config/environment';
+
+export default Ember.Controller.extend({
+  // get client id from config
+  clientId: config.APP.mapillaryClientId,
+  startKey: 'ytfE1_iD_N-jmHfTHkj1Ug',
+  moveToKey: undefined,
+  isResetDisabled: true,
+  actions: {
+    resetViewer() {
+      this.set('moveToKey', this.get('startKey'));
+    },
+    nodeDidChange() {
+      // allow reset
+      this.set('isResetDisabled', false);
+      // clear the previous move to key (if any)
+      // to allow the user to reset the view again
+      this.set('moveToKey', null);
+    }
+  }
+});

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -3,12 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>ember-cli-mapillary</title>
+    <title>Mapillary for Ember (ember-cli-mapillary)</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-
-    <!-- TODO: remove mapillary css/js from this file -->
-    <link rel="stylesheet" href="https://npmcdn.com/mapillary-js@1.3.0/dist/mapillary-js.min.css" />
 
     {{content-for "head"}}
 

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -9,6 +9,7 @@ Router.map(function() {
   this.route('simple');
   this.route('map-two-way');
   this.route('map-one-way');
+  this.route('move-to-key');
 });
 
 export default Router;

--- a/tests/dummy/app/routes/move-to-key.js
+++ b/tests/dummy/app/routes/move-to-key.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,5 +1,10 @@
-<h2 id="title">Mapillary for Ember</h2>
+<h2 id="title">Mapillary for Ember (ember-cli-mapillary)</h2>
 <p>Examples: {{#link-to "simple"}}Simple{{/link-to}}
  | {{#link-to "map-one-way"}}Map (One Way){{/link-to}}
- | {{#link-to "map-two-way"}}Map (Two Way){{/link-to}}</p>
+ | {{#link-to "map-two-way"}}Map (Two Way){{/link-to}}
+ | {{#link-to "move-to-key"}}Move to Key (ID){{/link-to}}</p>
 {{outlet}}
+<p>
+  Resources: <a href="https://github.com/esridc/ember-cli-mapillary">GitHub</a>
+    <a href="https://mapillary.github.io/mapillary-js/">MapillaryJS</a>
+</p>

--- a/tests/dummy/app/templates/move-to-key.hbs
+++ b/tests/dummy/app/templates/move-to-key.hbs
@@ -1,0 +1,9 @@
+<h3>Move to Key</h3>
+<p>Click on the viewer to begin navigating through the area. To go back to the start, click the <strong>Reset</strong> button below.</p>
+<div class="mly-wrapper">
+  {{!-- NOTE: clientId is defined in config/environment.js --}}
+  {{mapillary-viewer clientId=clientId key=startKey moveTo=moveToKey onNodeChanged=(action 'nodeDidChange') }}
+</div>
+<p>
+  <button onclick={{action "resetViewer"}} disabled={{isResetDisabled}}>Reset</button>
+</p>


### PR DESCRIPTION
use correct Mapillary API method move to key (moveToKey, not moveCloseKey)
add example of how to use move to key in dummy app
add GitHub and MapillaryJS links to dummy app
update to MapillaryJS v1.4.2 

resolves #10 
